### PR TITLE
US phone number handling, DPost reversion, LP Registruota conditional filling, more in comments 

### DIFF
--- a/Helper Files/amzn_parser_constants.py
+++ b/Helper Files/amzn_parser_constants.py
@@ -181,7 +181,6 @@ DPOST_HEADERS = [
 # Mapping: key corresponds to DPost CSV template (only the ones used for data entry), value - corresponding amazon header title
 DPOST_HEADERS_MAPPING = {
     'NAME' : 'recipient-name',
-    'CUST_REF' : 'recipient-name',
     'RECIPIENT_PHONE' : 'buyer-phone-number',
     'RECIPIENT_EMAIL' : 'buyer-email',
     'ADDRESS_LINE_1' : 'ship-address-1',
@@ -322,4 +321,4 @@ DP_KEYWORDS = ['BICYCLE', 'THEORY11,', 'ELLUSIONIST', 'COPAG']
 
 EXPECTED_AMZN_CHANNELS = ['COM', 'EU']
 
-DPOST_TRACKED_COUNTRIES = ['ES', 'FR']
+LP_AMAZON_EU_REGISTRUOTA_COUNTRIES = DPOST_TRACKED_COUNTRIES = ['ES', 'FR']

--- a/Helper Files/main_amazon.py
+++ b/Helper Files/main_amazon.py
@@ -1,4 +1,4 @@
-from amzn_parser_utils import get_output_dir, is_windows_machine
+from amzn_parser_utils import get_output_dir, is_windows_machine, clean_phone_number
 from amzn_parser_constants import EXPECTED_AMZN_CHANNELS
 from etonas_xlsx_exporter import EtonasExporter
 from parse_orders import ParseOrders
@@ -46,7 +46,7 @@ def clean_orders(orders:list) -> list:
     '''replaces plus sign in phone numbers with 00'''
     for order in orders:
         try:
-            order['buyer-phone-number'] = order['buyer-phone-number'].replace('+', '00')
+            order['buyer-phone-number'] = clean_phone_number(order['buyer-phone-number'])
         except KeyError as e:
             logging.warning(f'New header in source file. Alert VBA on new header. Error: {e}')
             print(VBA_KEYERROR_ALERT)
@@ -57,7 +57,7 @@ def parse_export_orders(testing:bool, amzn_channel:str, skip_etonas:bool, cleane
     db_client = OrdersDB(cleaned_source_orders, loaded_txt)
     new_orders = db_client.get_new_orders_only()
     logging.info(f'Loaded txt contains: {len(cleaned_source_orders)}. Further processing: {len(new_orders)} orders')
-    ParseOrders(new_orders, db_client).export_orders(amzn_channel=amzn_channel, testing=testing, skip_etonas=skip_etonas)
+    ParseOrders(new_orders, db_client, amzn_channel).export_orders(testing=testing, skip_etonas=skip_etonas)
 
 def parse_args():
     '''returns arguments passed from VBA'''


### PR DESCRIPTION
-US phone number w/ extension handler w/ new
util funcs in main_amazon.py clean_orders func
-revert FR/ES to DPost Priority
-LP 'Registruota' conditional filling
-amzn_channel now as ParseOrders input arg to be available class wide
-export_csv ability to change delimiter
-DPost CUST_REF fixed (deleted from mapping)
-addtl constant var LP_AMAZON_REGISTRUOTA_COUNTRIES (so far equal to
existing DPOST_TRACKED_COUNTRIES
-recompiled exe